### PR TITLE
Single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ of underlaying calculator and change the behaviour of program.
       Intended fot bad quaility data with heavily overlapping peaks,
       which can not be determined correctly using other approaches.
     * **No peak fitting** - do not fit any curve to model peak in spectrum.
-      To be used in with **Single value txt** and **No background fitting**. 
+      To be used with **Single value txt** and **No background fitting**. 
   * Correcting strategies
     * **Vos R1** - correct for temperature difference accorging to the R1
       equation put forward in 1991 by Vos et al.
@@ -157,6 +157,6 @@ This software is made by
 [Daniel Tchoń](https://www.researchgate.net/profile/Daniel-Tchon),
 and distributed under an MIT license. It is in development and all
 tips, suggestions, or contributions are welcome and can be sent
-[here](mailto:dtchon@chem.uw.edu.pl).
+[here](mailto:dtchon@lbl.gov).
 If you have utilised pRuby in academic work, please let me know!
 If the tools find a wider use, a dedicated paper will be published.

--- a/README.md
+++ b/README.md
@@ -75,20 +75,22 @@ pRuby GUI provides a simple, minimalistic GUI with the following functionality:
       position. Multiple plots will be drawn on the same canvas if it stays open. 
     * **To reference** - Export current R1, t and p1 values as a new reference.
     * **From reference** - Import R1, r and p1 data from previously saved reference.
-    * **Drow on import** - Toggle this option on in order to automatically draw
+    * **Draw on import** - Toggle this option on in order to automatically draw
       every imported data on the active canvas.
 * **Methods** - switch between the strategies to affect the engine
 of underlaying calculator and change the behaviour of program.
   * Reading strategies
-    * **Raw txt** - when reading the spectrum, expect a raw txt file
+    * **Raw spectrum txt** - when reading the spectrum, expect a raw txt file
       with two columns containing a sequences of x and y values only.
-    * **Meta txt** - same as above, but ignore every line which
+    * **Metadata spectrum txt** - same as above, but ignore every line which
       can not be interpreted (default).
+    * **Single value txt** - expect only a single line with r1 value.
   * Backfitting strategies
     * **Linear Huber** - estimate the background using linear function fitting
       with Huber sigmas (large deviations from the line - peaks - are ignored).
     * **Linear Satelite** - estimate the background using linear function
       fitting with unit sigmas to 1 nm ranges of edge-most data only.
+    * **No background fitting** - do not fit any background - assume bg of 0.
   * Peakfitting strategies
     * **Gauss** - find the positions of R1 and R2 using two independent
       Gaussian function centered around each of them and fit to a very small
@@ -100,6 +102,8 @@ of underlaying calculator and change the behaviour of program.
       Gaussian curves to data: one for R1, one for R1, one low between them.
       Intended fot bad quaility data with heavily overlapping peaks,
       which can not be determined correctly using other approaches.
+    * **No peak fitting** - do not fit any curve to model peak in spectrum.
+      To be used in with **Single value txt** and **No background fitting**. 
   * Correcting strategies
     * **Vos R1** - correct for temperature difference accorging to the R1
       equation put forward in 1991 by Vos et al.
@@ -134,6 +138,7 @@ of underlaying calculator and change the behaviour of program.
       to increase clarity, e.g. when overlaying multiple spectra.
     * **Complex** - draw the same elements as **Simple**, but additionally
       plot background profile, fitting range, and determined R2 value as well.
+    * **Single line** - minimalistic; draw only a single vertical line at R1.
 * **?** - Show basic information about the program
 
 These and some other behaviour options are available and can be selected from the package

--- a/pruby/gui/app.py
+++ b/pruby/gui/app.py
@@ -161,7 +161,7 @@ class Application(tk.Frame):
 
     def change_file(self, filename):
         self.file.set(filename)
-        if filename is '':
+        if filename == '':
             return
         try:
             self.calc.read(filename)

--- a/pruby/strategies/backfitting.py
+++ b/pruby/strategies/backfitting.py
@@ -70,3 +70,12 @@ class SateliteBackfittingStrategy(BaseBackfittingStrategy):
         self._approximate_linearly(calc.back_spectrum)
         calc.back_spectrum.focus_on_edge(width=1.0)
         calc.back_spectrum.sigma_type = 'equal'
+
+
+@BackfittingStrategies.register()
+class NullBackfittingStrategy(BackfittingStrategy):
+    name = 'No background fitting'
+
+    def backfit(self, calc):
+        calc.back_spectrum = copy.deepcopy(calc.raw_spectrum)
+        calc.back_spectrum.y = calc.back_spectrum.y * 0.0

--- a/pruby/strategies/drawing.py
+++ b/pruby/strategies/drawing.py
@@ -2,6 +2,8 @@ import abc
 from collections import OrderedDict
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
+
 from pruby.strategies import BaseStrategy, BaseStrategies
 from pruby.utility import cycle
 
@@ -121,4 +123,24 @@ class ComplexDrawingStrategy(BaseDrawingStrategy):
         self.draw_finalize()
 
 
+@DrawingStrategies.register()
+class SingleLineDrawingStrategy(BaseDrawingStrategy):
+    name = 'Single line'
 
+    def draw_finalize(self):
+        self.ax.annotate('nm', xy=(1, 0), ha='left', va='top',
+                         xytext=(10, - 3 - mpl.rcParams['xtick.major.pad']),
+                         xycoords='axes fraction', textcoords='offset points')
+        self.ax.legend()
+        self.calc.fig = self.fig
+        if self.interactive:
+            self.fig.show()
+        else:
+            self.fig.savefig(self.calc.output_path)
+
+    def draw(self, calc):
+        self.draw_initialize(calc)
+        self.draw_grid_and_tics()
+        self.draw_spectrum([np.NaN], [np.NaN])
+        self.draw_vline(calc.r1.n)
+        self.draw_finalize()

--- a/pruby/strategies/peakfitting.py
+++ b/pruby/strategies/peakfitting.py
@@ -144,3 +144,11 @@ class CamelPeakfittingStrategy(BasePeakfittingStrategy):
         curve = calc.peak_spectrum.curve
         calc.r1 = self.ufloat_from_curve_args(curve, index=1)
         calc.r2 = self.ufloat_from_curve_args(curve, index=4)
+
+
+@PeakfittingStrategies.register()
+class NullPeakfittingStrategy(PeakfittingStrategy):
+    name = 'No peak fitting'
+
+    def peakfit(self, calc):
+        curve = Curve()

--- a/pruby/strategies/reading.py
+++ b/pruby/strategies/reading.py
@@ -1,6 +1,7 @@
 import abc
 import numpy as np
 from collections import OrderedDict
+from uncertainties import ufloat_fromstr
 from pruby.strategies.base import BaseStrategy, BaseStrategies
 from pruby.spectrum import Spectrum
 
@@ -56,10 +57,11 @@ class SingleLineReadingStrategy(ReadingStrategy):
     @staticmethod
     def read(calc):
         with open(calc.dat_path, 'r') as file:
-            first_line = file.readline().split(' ')
-            r1 = float(first_line[0])
+            first_line = file.readline().split()
+            r1 = ufloat_fromstr(first_line[0])
             try:
-                intensity = float(first_line[1])
+                intensity = ufloat_fromstr(first_line[1])
             except (IndexError, ValueError):
                 intensity = 1
-        calc.raw_spectrum = Spectrum([r1], [intensity])
+        calc.raw_spectrum = calc.peak_spectrum = Spectrum([r1], [intensity])
+        calc.r1 = r1

--- a/pruby/strategies/reading.py
+++ b/pruby/strategies/reading.py
@@ -19,7 +19,7 @@ class ReadingStrategies(BaseStrategies):
 
 @ReadingStrategies.register()
 class RawTxtReadingStrategy(ReadingStrategy):
-    name = 'Raw txt'
+    name = 'Raw spectrum txt'
 
     @staticmethod
     def read(calc):
@@ -30,11 +30,11 @@ class RawTxtReadingStrategy(ReadingStrategy):
 
 @ReadingStrategies.register(default=True)
 class MetaTxtReadingStrategy(ReadingStrategy):
-    name = 'Metadata txt'
+    name = 'Metadata spectrum txt'
 
     @staticmethod
     def read(calc):
-        with open(calc.dat_path, "r") as file:
+        with open(calc.dat_path, 'r') as file:
             x_list, y_list = [], []
             for line in file.readlines():
                 try:
@@ -47,3 +47,19 @@ class MetaTxtReadingStrategy(ReadingStrategy):
                     x_list.append(new_x)
                     y_list.append(new_y)
         calc.raw_spectrum = Spectrum(x_list, y_list).within(calc.limits)
+
+
+@ReadingStrategies.register()
+class SingleLineReadingStrategy(ReadingStrategy):
+    name = 'Single value txt'
+
+    @staticmethod
+    def read(calc):
+        with open(calc.dat_path, 'r') as file:
+            first_line = file.readline().split(' ')
+            r1 = float(first_line[0])
+            try:
+                intensity = float(first_line[1])
+            except (IndexError, ValueError):
+                intensity = 1
+        calc.raw_spectrum = Spectrum([r1], [intensity])

--- a/pruby/utility/line_subset.py
+++ b/pruby/utility/line_subset.py
@@ -17,8 +17,8 @@ class LineSubset:
     # SEGMENT METHODS
     class LineSegment:
         def __init__(self, left=None, right=None):
-            if left >= right:
-                raise ValueError('Left ({}) >= Right ({})'.format(left, right))
+            if left > right:
+                raise ValueError('Left ({}) > Right ({})'.format(left, right))
             self.left = left
             self.right = right
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 
 setup(
     name='pruby',
-    version='0.1.2',
+    version='0.1.3',
     author='Daniel Tchoń',
     author_email='dtchon@chem.uw.edu.pl',
     packages=find_packages(exclude=('legacy', 'cli')),

--- a/test/test_calculator.py
+++ b/test/test_calculator.py
@@ -129,7 +129,7 @@ class TestCalculator(unittest.TestCase):
 
     def test_reading_and_fitting_meta_file(self):
         calc = PressureCalculator()
-        calc.engine.set_strategy(reading='Metadata txt')
+        calc.engine.set_strategy(reading='Metadata spectrum txt')
         calc.read(test_data2_path)
         self.assertGreater(calc.r1.n, 694.0)
 


### PR DESCRIPTION
Add full support for single-line files with R1 value only. The second value in the first row can be input as peak intensity, if present. Rest of the file is ignored. Added ability not to fit background or peak to the spectrum, which does not exist in the above case. This modification is handy to work in a consistent way with manually generated R1 values without artificially generating a spectrum for them.